### PR TITLE
Added max_iter_GD parameter to computeEmbedding() in utilsMDS.py

### DIFF
--- a/next/apps/PoolBasedTripletMDS/RandomSampling/utilsMDS.py
+++ b/next/apps/PoolBasedTripletMDS/RandomSampling/utilsMDS.py
@@ -183,7 +183,7 @@ def getGradient(X,S):
 
     return G,avg_grad_row_norm_sq,max_grad_row_norm_sq,avg_row_norm_sq
 
-def computeEmbedding(n,d,S,num_random_restarts=0,max_num_passes_SGD=0,max_iter_GD=0,max_norm=0,epsilon=0.01,verbose=False):
+def computeEmbedding(n,d,S,num_random_restarts=0,max_num_passes=0,max_iter_GD=0,max_norm=0,epsilon=0.01,verbose=False):
     """
     Computes an embedding of n objects in d dimensions usin the triplets of S.
     S is a list of triplets such that for each q in S, q = [i,j,k] means that
@@ -196,7 +196,7 @@ def computeEmbedding(n,d,S,num_random_restarts=0,max_num_passes_SGD=0,max_iter_G
         (int) num_random_restarts : number of random restarts (nonconvex
         optimization, may converge to local minima). E.g., 9 random restarts
         means take the best of 10 runs of the optimization routine.
-        (int) max_num_passes_SGD : maximum number of passes over data SGD makes before proceeding to GD (default equals 16)
+        (int) max_num_passes : maximum number of passes over data SGD makes before proceeding to GD (default equals 16)
         (int) max_iter_GD: maximum number of GD iteration (default equals 50)
         (float) max_norm : the maximum allowed norm of any one object (default equals 10*d)
         (float) epsilon : parameter that controls stopping condition, smaller means more accurate (default = 0.01)
@@ -207,8 +207,11 @@ def computeEmbedding(n,d,S,num_random_restarts=0,max_num_passes_SGD=0,max_iter_G
         (float) gamma : Equal to a/b where a is max row norm of the gradient matrix and b is the avg row norm of the centered embedding matrix X. This is a means to determine how close the current solution is to the "best" solution.  
     """
 
-    if max_num_passes_SGD==0:
+    if max_num_passes==0:
         max_num_passes_SGD = 16
+    else:
+        max_num_passes_SGD = max_num_passes
+
 
     if max_iter_GD ==0:
         max_iter_GD = 50

--- a/next/apps/PoolBasedTripletMDS/UncertaintySampling/utilsMDS.py
+++ b/next/apps/PoolBasedTripletMDS/UncertaintySampling/utilsMDS.py
@@ -183,7 +183,7 @@ def getGradient(X,S):
 
     return G,avg_grad_row_norm_sq,max_grad_row_norm_sq,avg_row_norm_sq
 
-def computeEmbedding(n,d,S,num_random_restarts=0,max_num_passes_SGD=0,max_iter_GD=0,max_norm=0,epsilon=0.01,verbose=False):
+def computeEmbedding(n,d,S,num_random_restarts=0,max_num_passes=0,max_iter_GD=0,max_norm=0,epsilon=0.01,verbose=False):
     """
     Computes an embedding of n objects in d dimensions usin the triplets of S.
     S is a list of triplets such that for each q in S, q = [i,j,k] means that
@@ -196,7 +196,7 @@ def computeEmbedding(n,d,S,num_random_restarts=0,max_num_passes_SGD=0,max_iter_G
         (int) num_random_restarts : number of random restarts (nonconvex
         optimization, may converge to local minima). E.g., 9 random restarts
         means take the best of 10 runs of the optimization routine.
-        (int) max_num_passes_SGD : maximum number of passes over data SGD makes before proceeding to GD (default equals 16)
+        (int) max_num_passes : maximum number of passes over data SGD makes before proceeding to GD (default equals 16)
         (int) max_iter_GD: maximum number of GD iteration (default equals 50)
         (float) max_norm : the maximum allowed norm of any one object (default equals 10*d)
         (float) epsilon : parameter that controls stopping condition, smaller means more accurate (default = 0.01)
@@ -207,8 +207,11 @@ def computeEmbedding(n,d,S,num_random_restarts=0,max_num_passes_SGD=0,max_iter_G
         (float) gamma : Equal to a/b where a is max row norm of the gradient matrix and b is the avg row norm of the centered embedding matrix X. This is a means to determine how close the current solution is to the "best" solution.  
     """
 
-    if max_num_passes_SGD==0:
+    if max_num_passes==0:
         max_num_passes_SGD = 16
+    else:
+        max_num_passes_SGD = max_num_passes
+
 
     if max_iter_GD ==0:
         max_iter_GD = 50


### PR DESCRIPTION
It was not possible to set the max_iters parameter of computeEmbeddingWithGD() from computeEmbedding(), which is it's primary interface. In addition, computeEmbedding() was ignoring some of the parameters it was passed in favor of hard-coded values.

I added computeEmbedding(..., max_iter_GD=0), and revised arguments to computeEmbeddingWithEpochSGD() and computeEmbeddingWithGD() so that they are receiving the relevant variables instead of constants.

Adding a parameter to computeEmbedding() has the potential to break other code if arguments were passed by position.